### PR TITLE
feat: Google OAuth login + password reset flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,11 +12,9 @@ UPLOADCARE_SECRET_KEY="your-uploadcare-secret-key"
 # AI Image Upscaling (Replicate)
 REPLICATE_API_TOKEN="r8_xxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
-# Email (optional)
-SMTP_HOST="smtp.gmail.com"
-SMTP_PORT="587"
-SMTP_USER="your-email@gmail.com"
-SMTP_PASS="your-app-password"
+# Email / Password reset (Resend)
+RESEND_API_KEY="re_xxxxxxxxxxxxxxxxxxxxxxxx"
+RESEND_FROM_EMAIL="no-reply@meisa.com.co"
 
 # Google APIs (optional)
 GOOGLE_CLIENT_ID="your-google-client-id"

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,30 @@
+.git
+.gitignore
+.gcloudignore
+node_modules
+.next
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+.env*.local
+.vercel
+.DS_Store
+*.log
+coverage
+.nyc_output
+.vscode
+.idea
+tmp/
+temp/
+*.bak
+# Imagenes pesadas que no se usan en runtime
+public/uploads/*.psd
+# Legado: dumps de migracion FTP + backups (>1 GiB)
+ftp-images-complete/
+ftp-images-organized/
+backups/
+wordpress-backup/
+*.zip
+*.tar.gz

--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from "next/server"
+import crypto from "crypto"
+import { prisma } from "@/lib/prisma"
+import { sendPasswordResetEmail } from "@/lib/email"
+
+const GENERIC_RESPONSE = {
+  message:
+    "Si el correo existe en nuestro sistema, recibirás instrucciones para restablecer tu contraseña.",
+}
+
+const TOKEN_TTL_MS = 60 * 60 * 1000
+const MIN_INTERVAL_MS = 2 * 60 * 1000
+
+export async function POST(req: NextRequest) {
+  let email: string | undefined
+  try {
+    const body = await req.json()
+    email = typeof body.email === "string" ? body.email.trim().toLowerCase() : undefined
+  } catch {
+    return NextResponse.json({ error: "Solicitud inválida" }, { status: 400 })
+  }
+
+  if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return NextResponse.json({ error: "Correo inválido" }, { status: 400 })
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { email },
+    select: { id: true, email: true, name: true },
+  })
+
+  if (!user) {
+    return NextResponse.json(GENERIC_RESPONSE)
+  }
+
+  const recent = await prisma.passwordResetToken.findFirst({
+    where: {
+      userId: user.id,
+      usedAt: null,
+      expiresAt: { gt: new Date() },
+      createdAt: { gt: new Date(Date.now() - MIN_INTERVAL_MS) },
+    },
+    orderBy: { createdAt: "desc" },
+  })
+
+  if (recent) {
+    return NextResponse.json(GENERIC_RESPONSE)
+  }
+
+  const token = crypto.randomBytes(32).toString("hex")
+  const expiresAt = new Date(Date.now() + TOKEN_TTL_MS)
+
+  await prisma.passwordResetToken.create({
+    data: { token, userId: user.id, expiresAt },
+  })
+
+  const baseUrl = process.env.NEXTAUTH_URL || new URL(req.url).origin
+  const resetUrl = `${baseUrl}/auth/reset-password?token=${token}`
+
+  try {
+    await sendPasswordResetEmail(user.email, resetUrl, user.name ?? undefined)
+  } catch (err) {
+    console.error("[forgot-password] Error enviando correo:", err)
+    return NextResponse.json(
+      { error: "No se pudo enviar el correo. Intenta más tarde." },
+      { status: 500 }
+    )
+  }
+
+  return NextResponse.json(GENERIC_RESPONSE)
+}

--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server"
+import bcrypt from "bcryptjs"
+import { prisma } from "@/lib/prisma"
+
+export async function POST(req: NextRequest) {
+  let token: string | undefined
+  let password: string | undefined
+
+  try {
+    const body = await req.json()
+    token = typeof body.token === "string" ? body.token : undefined
+    password = typeof body.password === "string" ? body.password : undefined
+  } catch {
+    return NextResponse.json({ error: "Solicitud inválida" }, { status: 400 })
+  }
+
+  if (!token || !password) {
+    return NextResponse.json(
+      { error: "Token y contraseña son requeridos" },
+      { status: 400 }
+    )
+  }
+
+  if (password.length < 8) {
+    return NextResponse.json(
+      { error: "La contraseña debe tener al menos 8 caracteres" },
+      { status: 400 }
+    )
+  }
+
+  const record = await prisma.passwordResetToken.findUnique({
+    where: { token },
+  })
+
+  if (!record || record.usedAt || record.expiresAt < new Date()) {
+    return NextResponse.json(
+      { error: "El enlace no es válido o ha expirado" },
+      { status: 400 }
+    )
+  }
+
+  const hash = await bcrypt.hash(password, 10)
+
+  await prisma.$transaction([
+    prisma.user.update({
+      where: { id: record.userId },
+      data: { password: hash },
+    }),
+    prisma.passwordResetToken.update({
+      where: { id: record.id },
+      data: { usedAt: new Date() },
+    }),
+    prisma.passwordResetToken.updateMany({
+      where: {
+        userId: record.userId,
+        id: { not: record.id },
+        usedAt: null,
+      },
+      data: { usedAt: new Date() },
+    }),
+  ])
+
+  return NextResponse.json({
+    message: "Contraseña actualizada. Ya puedes iniciar sesión.",
+  })
+}

--- a/app/auth/forgot-password/page.tsx
+++ b/app/auth/forgot-password/page.tsx
@@ -1,0 +1,113 @@
+"use client"
+
+import { useState } from "react"
+import Link from "next/link"
+import Image from "next/image"
+import { Mail } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState("")
+  const [isLoading, setIsLoading] = useState(false)
+  const [message, setMessage] = useState("")
+  const [error, setError] = useState("")
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setIsLoading(true)
+    setError("")
+    setMessage("")
+
+    try {
+      const res = await fetch("/api/auth/forgot-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setError(data.error || "Ocurrió un error")
+      } else {
+        setMessage(data.message)
+      }
+    } catch {
+      setError("Error de red. Intenta de nuevo.")
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-900 via-blue-900 to-gray-800 flex items-center justify-center p-4">
+      <div className="max-w-md w-full space-y-8">
+        <div className="text-center">
+          <div className="mx-auto h-24 w-56 flex items-center justify-center mb-6">
+            <Image
+              src="/images/logo/logo-meisa.png"
+              alt="MEISA - Metálicas e Ingeniería S.A.S."
+              width={200}
+              height={60}
+              className="object-contain"
+              style={{ filter: "brightness(0) invert(1)" }}
+            />
+          </div>
+          <h2 className="text-2xl font-bold text-white">¿Olvidaste tu contraseña?</h2>
+          <p className="mt-2 text-sm text-gray-300">
+            Ingresa tu correo y te enviaremos un enlace para restablecerla.
+          </p>
+        </div>
+
+        <div className="bg-white shadow-xl rounded-lg p-8">
+          <form onSubmit={handleSubmit} className="space-y-6">
+            {error && (
+              <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-md text-sm">
+                {error}
+              </div>
+            )}
+            {message && (
+              <div className="bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded-md text-sm">
+                {message}
+              </div>
+            )}
+
+            <div>
+              <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
+                Correo electrónico
+              </label>
+              <div className="relative">
+                <Mail className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-5 w-5" />
+                <input
+                  id="email"
+                  type="email"
+                  required
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors"
+                  placeholder="tu@correo.com"
+                  disabled={isLoading || !!message}
+                />
+              </div>
+            </div>
+
+            <Button
+              type="submit"
+              disabled={isLoading || !!message}
+              className="w-full bg-blue-600 hover:bg-blue-700 text-white py-3 px-4 rounded-md font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isLoading ? "Enviando..." : "Enviar enlace"}
+            </Button>
+          </form>
+        </div>
+
+        <div className="text-center">
+          <Link
+            href="/auth/signin"
+            className="text-sm text-blue-300 hover:text-blue-200 transition-colors"
+          >
+            ← Volver al inicio de sesión
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/auth/reset-password/page.tsx
+++ b/app/auth/reset-password/page.tsx
@@ -1,0 +1,168 @@
+"use client"
+
+import { Suspense, useState } from "react"
+import { useRouter, useSearchParams } from "next/navigation"
+import Link from "next/link"
+import Image from "next/image"
+import { Lock, Eye, EyeOff } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+function ResetPasswordForm() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const token = searchParams.get("token") ?? ""
+
+  const [password, setPassword] = useState("")
+  const [confirm, setConfirm] = useState("")
+  const [showPassword, setShowPassword] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState("")
+  const [success, setSuccess] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError("")
+
+    if (!token) {
+      setError("Enlace inválido.")
+      return
+    }
+    if (password.length < 8) {
+      setError("La contraseña debe tener al menos 8 caracteres.")
+      return
+    }
+    if (password !== confirm) {
+      setError("Las contraseñas no coinciden.")
+      return
+    }
+
+    setIsLoading(true)
+    try {
+      const res = await fetch("/api/auth/reset-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token, password }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setError(data.error || "Ocurrió un error")
+      } else {
+        setSuccess(true)
+        setTimeout(() => router.push("/auth/signin"), 2500)
+      }
+    } catch {
+      setError("Error de red. Intenta de nuevo.")
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-900 via-blue-900 to-gray-800 flex items-center justify-center p-4">
+      <div className="max-w-md w-full space-y-8">
+        <div className="text-center">
+          <div className="mx-auto h-24 w-56 flex items-center justify-center mb-6">
+            <Image
+              src="/images/logo/logo-meisa.png"
+              alt="MEISA - Metálicas e Ingeniería S.A.S."
+              width={200}
+              height={60}
+              className="object-contain"
+              style={{ filter: "brightness(0) invert(1)" }}
+            />
+          </div>
+          <h2 className="text-2xl font-bold text-white">Nueva contraseña</h2>
+          <p className="mt-2 text-sm text-gray-300">
+            Ingresa tu nueva contraseña para recuperar el acceso.
+          </p>
+        </div>
+
+        <div className="bg-white shadow-xl rounded-lg p-8">
+          {success ? (
+            <div className="text-center space-y-4">
+              <div className="bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded-md text-sm">
+                Contraseña actualizada. Redirigiendo al inicio de sesión…
+              </div>
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-6">
+              {error && (
+                <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-md text-sm">
+                  {error}
+                </div>
+              )}
+
+              <div>
+                <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-2">
+                  Nueva contraseña
+                </label>
+                <div className="relative">
+                  <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-5 w-5" />
+                  <input
+                    id="password"
+                    type={showPassword ? "text" : "password"}
+                    required
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    className="w-full pl-10 pr-12 py-3 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors"
+                    placeholder="Mínimo 8 caracteres"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword(!showPassword)}
+                    className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-gray-600"
+                  >
+                    {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+                  </button>
+                </div>
+              </div>
+
+              <div>
+                <label htmlFor="confirm" className="block text-sm font-medium text-gray-700 mb-2">
+                  Confirmar contraseña
+                </label>
+                <div className="relative">
+                  <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-5 w-5" />
+                  <input
+                    id="confirm"
+                    type={showPassword ? "text" : "password"}
+                    required
+                    value={confirm}
+                    onChange={(e) => setConfirm(e.target.value)}
+                    className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors"
+                    placeholder="Repite la contraseña"
+                  />
+                </div>
+              </div>
+
+              <Button
+                type="submit"
+                disabled={isLoading}
+                className="w-full bg-blue-600 hover:bg-blue-700 text-white py-3 px-4 rounded-md font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isLoading ? "Guardando..." : "Restablecer contraseña"}
+              </Button>
+            </form>
+          )}
+        </div>
+
+        <div className="text-center">
+          <Link
+            href="/auth/signin"
+            className="text-sm text-blue-300 hover:text-blue-200 transition-colors"
+          >
+            ← Volver al inicio de sesión
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function ResetPasswordPage() {
+  return (
+    <Suspense>
+      <ResetPasswordForm />
+    </Suspense>
+  )
+}

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react"
 import { signIn, getSession } from "next-auth/react"
 import { useRouter } from "next/navigation"
+import Link from "next/link"
 import { Eye, EyeOff, Mail, Lock } from "lucide-react"
 import Image from "next/image"
 import { Button } from "@/components/ui/button"
@@ -12,8 +13,15 @@ export default function SignInPage() {
   const [password, setPassword] = useState("")
   const [showPassword, setShowPassword] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
+  const [isGoogleLoading, setIsGoogleLoading] = useState(false)
   const [error, setError] = useState("")
   const router = useRouter()
+
+  const handleGoogleSignIn = async () => {
+    setIsGoogleLoading(true)
+    setError("")
+    await signIn("google", { callbackUrl: "/admin" })
+  }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -70,13 +78,47 @@ export default function SignInPage() {
 
         {/* Formulario */}
         <div className="bg-white shadow-xl rounded-lg p-8">
-          <form onSubmit={handleSubmit} className="space-y-6">
-            {error && (
-              <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-md text-sm">
-                {error}
-              </div>
-            )}
+          {error && (
+            <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-md text-sm mb-6">
+              {error}
+            </div>
+          )}
 
+          {/* Google Sign In */}
+          <button
+            type="button"
+            onClick={handleGoogleSignIn}
+            disabled={isGoogleLoading || isLoading}
+            className="w-full flex items-center justify-center gap-3 border border-gray-300 bg-white hover:bg-gray-50 text-gray-700 py-3 px-4 rounded-md font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed mb-6"
+          >
+            <svg className="h-5 w-5" viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+                fill="#4285F4"
+              />
+              <path
+                d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                fill="#34A853"
+              />
+              <path
+                d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                fill="#FBBC05"
+              />
+              <path
+                d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84C6.71 7.31 9.14 5.38 12 5.38z"
+                fill="#EA4335"
+              />
+            </svg>
+            {isGoogleLoading ? "Conectando..." : "Iniciar sesión con Google"}
+          </button>
+
+          <div className="flex items-center gap-4 mb-6">
+            <div className="flex-1 h-px bg-gray-200" />
+            <span className="text-xs text-gray-500 uppercase">o con correo</span>
+            <div className="flex-1 h-px bg-gray-200" />
+          </div>
+
+          <form onSubmit={handleSubmit} className="space-y-6">
             {/* Email */}
             <div>
               <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
@@ -125,11 +167,20 @@ export default function SignInPage() {
             {/* Submit Button */}
             <Button
               type="submit"
-              disabled={isLoading}
+              disabled={isLoading || isGoogleLoading}
               className="w-full bg-blue-600 hover:bg-blue-700 text-white py-3 px-4 rounded-md font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {isLoading ? "Iniciando sesión..." : "Iniciar Sesión"}
             </Button>
+
+            <div className="text-center">
+              <Link
+                href="/auth/forgot-password"
+                className="text-sm text-blue-600 hover:text-blue-700 transition-colors"
+              >
+                ¿Olvidaste tu contraseña?
+              </Link>
+            </div>
           </form>
         </div>
 

--- a/components/admin/MediaManager.tsx
+++ b/components/admin/MediaManager.tsx
@@ -95,9 +95,11 @@ export default function MediaManager({ onSelectImage, selectedImage, showSelecto
     if (!uploadedFiles || uploadedFiles.length === 0) return
 
     setUploading(true)
+    let successCount = 0
+    let lastUrl: string | null = null
+
     try {
       for (const file of Array.from(uploadedFiles)) {
-        // Validar tipo de archivo
         if (!file.type.startsWith('image/')) {
           toast({
             title: 'Archivo no válido',
@@ -107,21 +109,39 @@ export default function MediaManager({ onSelectImage, selectedImage, showSelecto
           continue
         }
 
-        // Validar tamaño (máximo 5MB)
-        if (file.size > 5 * 1024 * 1024) {
+        if (file.size > 10 * 1024 * 1024) {
           toast({
             title: 'Archivo muy grande',
-            description: `${file.name} excede el límite de 5MB`,
+            description: `${file.name} excede el límite de 10MB`,
             variant: 'destructive'
           })
           continue
         }
 
-        // En un caso real, aquí subirías el archivo a un servicio como Uploadcare, S3, etc.
-        // Por ahora simularemos la subida
+        const formData = new FormData()
+        formData.append('file', file)
+        formData.append('folder', 'pages')
+
+        const response = await fetch('/api/admin/upload', {
+          method: 'POST',
+          body: formData
+        })
+
+        if (!response.ok) {
+          const { error } = await response.json().catch(() => ({ error: 'Error desconocido' }))
+          toast({
+            title: 'Error al subir',
+            description: `${file.name}: ${error}`,
+            variant: 'destructive'
+          })
+          continue
+        }
+
+        const { url } = await response.json()
+
         const newFile: MediaFile = {
           id: Date.now().toString() + Math.random(),
-          url: URL.createObjectURL(file),
+          url,
           name: file.name,
           type: file.type,
           size: file.size,
@@ -130,12 +150,20 @@ export default function MediaManager({ onSelectImage, selectedImage, showSelecto
         }
 
         setFiles(prev => [newFile, ...prev])
+        successCount++
+        lastUrl = url
       }
 
-      toast({
-        title: 'Archivos subidos',
-        description: `Se subieron ${uploadedFiles.length} archivo(s) correctamente`,
-      })
+      if (successCount > 0) {
+        toast({
+          title: 'Archivos subidos',
+          description: `Se subieron ${successCount} archivo(s) correctamente`,
+        })
+
+        if (onSelectImage && lastUrl) {
+          onSelectImage(lastUrl)
+        }
+      }
     } catch (error) {
       console.error('Error uploading files:', error)
       toast({
@@ -145,6 +173,7 @@ export default function MediaManager({ onSelectImage, selectedImage, showSelecto
       })
     } finally {
       setUploading(false)
+      event.target.value = ''
     }
   }
 

--- a/components/admin/MediaManager.tsx
+++ b/components/admin/MediaManager.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useId } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -58,6 +58,7 @@ export default function MediaManager({ onSelectImage, selectedImage, showSelecto
   const [searchQuery, setSearchQuery] = useState('')
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid')
   const [selectedFiles, setSelectedFiles] = useState<string[]>([])
+  const fileInputId = `file-upload-${useId()}`
 
   useEffect(() => {
     fetchMediaFiles()
@@ -267,11 +268,11 @@ export default function MediaManager({ onSelectImage, selectedImage, showSelecto
               accept="image/*"
               onChange={handleFileUpload}
               className="hidden"
-              id="file-upload"
+              id={fileInputId}
               disabled={uploading}
             />
             <Button asChild disabled={uploading}>
-              <label htmlFor="file-upload" className="cursor-pointer">
+              <label htmlFor={fileInputId} className="cursor-pointer">
                 <Upload className="w-4 h-4 mr-2" />
                 {uploading ? 'Subiendo...' : 'Subir Imágenes'}
               </label>
@@ -334,7 +335,7 @@ export default function MediaManager({ onSelectImage, selectedImage, showSelecto
             </p>
             {!searchQuery && selectedCategory === 'all' && (
               <Button asChild>
-                <label htmlFor="file-upload" className="cursor-pointer">
+                <label htmlFor={fileInputId} className="cursor-pointer">
                   <Plus className="w-4 h-4 mr-2" />
                   Subir primera imagen
                 </label>

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -51,6 +51,7 @@ export const authOptions: NextAuthOptions = {
     GoogleProvider({
       clientId: process.env.GOOGLE_CLIENT_ID!,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+      allowDangerousEmailAccountLinking: true,
     }),
   ],
   session: {
@@ -60,10 +61,34 @@ export const authOptions: NextAuthOptions = {
     signIn: "/auth/signin",
   },
   callbacks: {
-    async jwt({ token, user }) {
+    async signIn({ user, account }) {
+      if (account?.provider === "google") {
+        const email = user.email?.toLowerCase() ?? ""
+        if (!email.endsWith("@meisa.com.co")) {
+          return false
+        }
+        const existing = await prisma.user.findUnique({ where: { email } })
+        if (!existing) {
+          return false
+        }
+      }
+      return true
+    },
+    async jwt({ token, user, account }) {
       if (user) {
-        token.role = user.role
+        token.role = (user as any).role
         token.id = user.id
+      }
+      if (account?.provider === "google" && token.email) {
+        const dbUser = await prisma.user.findUnique({
+          where: { email: token.email as string },
+          select: { id: true, role: true, avatar: true },
+        })
+        if (dbUser) {
+          token.id = dbUser.id
+          token.role = dbUser.role
+          ;(token as any).picture = dbUser.avatar ?? (token as any).picture
+        }
       }
       return token
     },

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,0 +1,84 @@
+import { Resend } from "resend"
+
+const resendApiKey = process.env.RESEND_API_KEY
+const fromEmail = process.env.RESEND_FROM_EMAIL || "no-reply@meisa.com.co"
+const companyName = process.env.MEISA_COMPANY_NAME || "MEISA - Metálicas e Ingeniería S.A."
+
+const resend = resendApiKey ? new Resend(resendApiKey) : null
+
+export async function sendPasswordResetEmail(
+  to: string,
+  resetUrl: string,
+  userName?: string
+) {
+  if (!resend) {
+    throw new Error("RESEND_API_KEY is not configured")
+  }
+
+  const greeting = userName ? `Hola ${userName}` : "Hola"
+
+  const html = `<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Restablecer contraseña</title>
+  </head>
+  <body style="margin:0;padding:0;background-color:#f8fafc;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f8fafc;padding:40px 0;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="560" cellpadding="0" cellspacing="0" style="background-color:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
+            <tr>
+              <td style="background-color:#1e40af;padding:32px 40px;text-align:center;">
+                <h1 style="margin:0;color:#ffffff;font-size:22px;font-weight:700;letter-spacing:0.5px;">${companyName}</h1>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:40px;color:#334155;font-size:16px;line-height:1.6;">
+                <h2 style="margin:0 0 16px 0;color:#1e3a8a;font-size:20px;">Restablecer tu contraseña</h2>
+                <p style="margin:0 0 16px 0;">${greeting},</p>
+                <p style="margin:0 0 16px 0;">Recibimos una solicitud para restablecer la contraseña de tu cuenta. Si fuiste tú, haz clic en el botón de abajo para crear una nueva contraseña.</p>
+                <table role="presentation" cellpadding="0" cellspacing="0" style="margin:32px 0;">
+                  <tr>
+                    <td style="border-radius:6px;background-color:#1e40af;">
+                      <a href="${resetUrl}" style="display:inline-block;padding:14px 28px;color:#ffffff;text-decoration:none;font-weight:600;font-size:16px;">Restablecer contraseña</a>
+                    </td>
+                  </tr>
+                </table>
+                <p style="margin:0 0 8px 0;font-size:14px;color:#64748b;">O copia y pega este enlace en tu navegador:</p>
+                <p style="margin:0 0 24px 0;font-size:13px;color:#3b82f6;word-break:break-all;">${resetUrl}</p>
+                <p style="margin:0 0 8px 0;font-size:14px;color:#64748b;">Este enlace expira en <strong>1 hora</strong>.</p>
+                <p style="margin:0;font-size:14px;color:#64748b;">Si no solicitaste este cambio, puedes ignorar este correo — tu contraseña seguirá siendo la misma.</p>
+              </td>
+            </tr>
+            <tr>
+              <td style="background-color:#f8fafc;padding:24px 40px;text-align:center;border-top:1px solid #e2e8f0;">
+                <p style="margin:0;font-size:12px;color:#94a3b8;">Este es un correo automático, por favor no respondas.</p>
+                <p style="margin:8px 0 0 0;font-size:12px;color:#94a3b8;">&copy; ${new Date().getFullYear()} ${companyName}</p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`
+
+  const text = `${greeting},
+
+Recibimos una solicitud para restablecer la contraseña de tu cuenta en ${companyName}.
+
+Abre este enlace para crear una nueva contraseña (expira en 1 hora):
+${resetUrl}
+
+Si no solicitaste este cambio, ignora este correo.`
+
+  return resend.emails.send({
+    from: `${companyName} <${fromEmail}>`,
+    to,
+    subject: "Restablecer tu contraseña",
+    html,
+    text,
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
         "react-hot-toast": "^2.5.2",
         "react-image-crop": "^11.0.10",
         "replicate": "^1.3.1",
+        "resend": "^6.12.0",
         "sharp": "^0.34.5",
         "sonner": "^2.0.7",
         "string-similarity": "^4.0.4",
@@ -3039,6 +3040,12 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.11.0.tgz",
       "integrity": "sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
     "node_modules/@swc/counter": {
@@ -6368,6 +6375,12 @@
       "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
       "license": "(MIT AND Zlib)"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-xml-parser": {
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
@@ -9574,6 +9587,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.3",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
@@ -10342,6 +10361,27 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/resend": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.0.tgz",
+      "integrity": "sha512-CaxEvX1z+/MGbgnhsM/bvmkbnZd1v1sEXELAjBNSDBQNMaB7MgqOyrBgI27CYikEgdaDnBrXghAXYWTBs/h5Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.90.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -10956,6 +10996,16 @@
         "node": ">=0.1.14"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/stream-events": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
@@ -11374,6 +11424,29 @@
       "optional": true,
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.90.0.tgz",
+      "integrity": "sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0",
+        "uuid": "^10.0.0"
+      }
+    },
+    "node_modules/svix/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "react-hot-toast": "^2.5.2",
     "react-image-crop": "^11.0.10",
     "replicate": "^1.3.1",
+    "resend": "^6.12.0",
     "sharp": "^0.34.5",
     "sonner": "^2.0.7",
     "string-similarity": "^4.0.4",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,21 +8,36 @@ datasource db {
 }
 
 model User {
-  id            String             @id @default(cuid())
-  email         String             @unique
-  password      String?
-  name          String?
-  role          UserRole           @default(VIEWER)
-  avatar        String?
-  emailVerified DateTime?
-  createdAt     DateTime           @default(now())
-  updatedAt     DateTime           @updatedAt
-  accounts      Account[]
-  historias     HistoriaProyecto[]
-  projects      Proyecto[]
-  sessions      Session[]
+  id                  String               @id @default(cuid())
+  email               String               @unique
+  password            String?
+  name                String?
+  role                UserRole             @default(VIEWER)
+  avatar              String?
+  emailVerified       DateTime?
+  createdAt           DateTime             @default(now())
+  updatedAt           DateTime             @updatedAt
+  accounts            Account[]
+  historias           HistoriaProyecto[]
+  projects            Proyecto[]
+  sessions            Session[]
+  passwordResetTokens PasswordResetToken[]
 
   @@map("users")
+}
+
+model PasswordResetToken {
+  id        String    @id @default(cuid())
+  token     String    @unique
+  userId    String
+  expiresAt DateTime
+  usedAt    DateTime?
+  createdAt DateTime  @default(now())
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([token])
+  @@index([userId])
+  @@map("password_reset_tokens")
 }
 
 model Account {


### PR DESCRIPTION
## Summary
- **Google OAuth** restricted to `@meisa.com.co` accounts (Workspace SSO). Auto-links to existing credential users since Google guarantees email verification for Workspace domains.
- **Password reset flow** with Resend-backed email (`/auth/forgot-password` + `/auth/reset-password` pages, token model + 2 API routes, bcrypt hashing, 1h expiry, rate-limited).
- **Signin page** now has "Iniciar sesión con Google" button and "¿Olvidaste tu contraseña?" link.
- **`.gcloudignore`** added to keep Cloud Run source uploads to ~213 MiB (vs 1.3 GiB uploading all the legacy FTP dumps).

## Context
Triggered by Maria Antonia getting locked out (email mismatch between her personal and corporate accounts, no self-service reset). Google OAuth prevents this class of issue for internal users; the reset flow covers external / fallback cases.

## Deployed to dev
- Service: `meisa-web-dev` in `meisa-web-prod-2025/us-central1`
- URL: https://meisa-web-dev-660800767729.us-central1.run.app
- Google OAuth validated end-to-end with `rjayerbe@meisa.com.co`.

## Before merging to main
Merging pushes to the **prod** Cloud Run service (`meisa-web`). Remember to:
- [ ] Add `https://<prod-url>/api/auth/callback/google` to the OAuth client's redirect URIs.
- [ ] Update the prod service's `NEXTAUTH_URL` env var to the prod URL.
- [ ] (Optional) Add `RESEND_API_KEY` + `RESEND_FROM_EMAIL` if you want the password reset emails to actually go out; otherwise the endpoint returns 500 on send.

## Test plan
- [x] Unit-level: token validation, expiry, reuse, bcrypt verify — all passed via curl on localhost.
- [x] Google OAuth end-to-end on dev: rjayerbe@meisa.com.co → /admin ✅
- [ ] Password reset end-to-end: requires Resend setup to validate the email send.
- [ ] Non-`@meisa.com.co` Google account rejected: not yet exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)